### PR TITLE
Improve benchmark with repeated runs

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,41 +1,64 @@
 import time
+import statistics
 from orchestrator import TaskOrchestrator
 
 EXAMPLES = [
-    # Prompts chosen to require up-to-date information so that
-    # the asynchronous search DAG provides a real advantage.
-    "Research the impact of AI on renewable energy.",
-    "Find recent developments in clean energy policy worldwide.",
-    "Gather the latest statistics on global electric vehicle adoption."
+    # Elaborate prompts to better stress the orchestration logic
+    "Research the long-term impact of artificial intelligence on renewable energy production, including potential breakthroughs, pitfalls, and cite at least five recent studies.",
+    "Detail recent developments in global clean energy policy since 2022, focusing on regulatory incentives and subsidies.",
+    "Compile the latest statistics on worldwide electric vehicle adoption and analyze regional trends and barriers to growth."
 ]
+
+
+NUM_RUNS = 20
 
 
 def benchmark():
     rows = []
     for prompt in EXAMPLES:
-        orch_tygent = TaskOrchestrator(silent=True, use_tygent=True)
-        start = time.perf_counter()
-        try:
-            orch_tygent.orchestrate(prompt)
-        except Exception:
-            pass
-        tygent_time = time.perf_counter() - start
+        tygent_times = []
+        thread_times = []
 
-        orch_thread = TaskOrchestrator(silent=True, use_tygent=False)
-        start = time.perf_counter()
-        try:
-            orch_thread.orchestrate(prompt)
-        except Exception:
-            pass
-        thread_time = time.perf_counter() - start
+        # Run with Tygent scheduler
+        for _ in range(NUM_RUNS):
+            orch_tygent = TaskOrchestrator(silent=True, use_tygent=True)
+            start = time.perf_counter()
+            try:
+                orch_tygent.orchestrate(prompt)
+            except Exception:
+                pass
+            tygent_times.append(time.perf_counter() - start)
 
-        rows.append((prompt, tygent_time, thread_time))
+        # Run with thread pool fallback
+        for _ in range(NUM_RUNS):
+            orch_thread = TaskOrchestrator(silent=True, use_tygent=False)
+            start = time.perf_counter()
+            try:
+                orch_thread.orchestrate(prompt)
+            except Exception:
+                pass
+            thread_times.append(time.perf_counter() - start)
 
-    print("Benchmark Results (seconds)")
-    print(f"{'Prompt':<40} {'Tygent':>10} {'Threads':>10}")
-    for prompt, t_time, thr_time in rows:
+        rows.append((prompt, tygent_times, thread_times))
+
+    print(f"Benchmark Results over {NUM_RUNS} runs (seconds)")
+    header = (
+        f"{'Prompt':<40} {'Avg T':>10} {'Med T':>10} {'Std T':>10}"
+        f" {'Avg Th':>10} {'Med Th':>10} {'Std Th':>10}"
+    )
+    print(header)
+    for prompt, t_times, thr_times in rows:
         label = (prompt[:37] + '...') if len(prompt) > 40 else prompt
-        print(f"{label:<40} {t_time:>10.2f} {thr_time:>10.2f}")
+        t_mean = statistics.mean(t_times)
+        t_median = statistics.median(t_times)
+        t_stdev = statistics.stdev(t_times) if len(t_times) > 1 else 0.0
+        thr_mean = statistics.mean(thr_times)
+        thr_median = statistics.median(thr_times)
+        thr_stdev = statistics.stdev(thr_times) if len(thr_times) > 1 else 0.0
+        print(
+            f"{label:<40} {t_mean:>10.2f} {t_median:>10.2f} {t_stdev:>10.2f}"
+            f" {thr_mean:>10.2f} {thr_median:>10.2f} {thr_stdev:>10.2f}"
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- expand benchmark prompts for additional complexity
- run each prompt 20 times
- report average, median and standard deviation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python benchmark.py`

------
https://chatgpt.com/codex/tasks/task_e_687ced3c68bc832b8aafe93f519a495a